### PR TITLE
Adds og:image and og:url Open Graph markup

### DIFF
--- a/ckanext/showcase/templates/showcase/read.html
+++ b/ckanext/showcase/templates/showcase/read.html
@@ -20,6 +20,10 @@
   {% set description = h.markdown_extract(pkg.notes, extract_length=200)|forceescape %}
   <meta property="og:title" content="{{ h.dataset_display_name(pkg) }} - {{ g.site_title }}">
   <meta property="og:description" content="{{ description|forceescape }}">
+  <meta property="og:url" content="{{ h.full_current_url() }}">
+  {% if pkg.image_display_url %}
+     <meta property="og:image" content="{{ pkg.image_display_url }}">
+  {% endif %}
 {% endblock -%}
 
 {% block breadcrumb_content_selected %} class="active"{% endblock %}


### PR DESCRIPTION
Implements #6.
It turns out you only need og:url and og:image, and showcases now get embedded properly.

See http://iframely.com/debug?uri=http%3A%2F%2Fdata.beta.nyc%2Fshowcase%2Fthe-children-of-vision-zero-2014