### PR TITLE
Header override

### DIFF
--- a/ckanext/showcase/templates/package/read_base.html
+++ b/ckanext/showcase/templates/package/read_base.html
@@ -1,8 +1,6 @@
 {% ckan_extends %}
 
 {% block content_primary_nav %}
-  {{ h.build_nav_icon('dataset_read', _('Dataset'), id=pkg.name) }}
-  {{ h.build_nav_icon('dataset_groups', _('Groups'), id=pkg.name) }}
-  {{ h.build_nav_icon('dataset_activity', _('Activity Stream'), id=pkg.name) }}
+  {{ super() }}
   {{ h.build_nav_icon('dataset_showcase_list', _('Showcases'), id=pkg.name) }}
 {% endblock %}

--- a/ckanext/showcase/templates/showcase/read.html
+++ b/ckanext/showcase/templates/showcase/read.html
@@ -66,6 +66,14 @@
       <p class="ckanext-showcase-image-container"><img src="{{ pkg.image_display_url }}" alt="{{ name }}" class="media-image ckanext-showcase-image"></p>
     {% endif %}
 
+    {% block package_notes %}
+      {% if pkg.showcase_notes_formatted %}
+        <div class="notes embedded-content ckanext-showcase-notes">
+          {{ pkg.showcase_notes_formatted }}
+        </div>
+      {% endif %}
+    {% endblock %}
+
     {% if pkg.url %}
       <p><a class="btn btn-primary ckanext-showcase-launch" href="{{ pkg.url }}" target="_blank"><i class="icon-external-link"></i> {{ _('Launch website') }}</a></p>
     {% endif %}

--- a/ckanext/showcase/templates/showcase/read.html
+++ b/ckanext/showcase/templates/showcase/read.html
@@ -66,14 +66,6 @@
       <p class="ckanext-showcase-image-container"><img src="{{ pkg.image_display_url }}" alt="{{ name }}" class="media-image ckanext-showcase-image"></p>
     {% endif %}
 
-    {% block package_notes %}
-      {% if pkg.showcase_notes_formatted %}
-        <div class="notes embedded-content ckanext-showcase-notes">
-          {{ pkg.showcase_notes_formatted }}
-        </div>
-      {% endif %}
-    {% endblock %}
-
     {% if pkg.url %}
       <p><a class="btn btn-primary ckanext-showcase-launch" href="{{ pkg.url }}" target="_blank"><i class="icon-external-link"></i> {{ _('Launch website') }}</a></p>
     {% endif %}


### PR DESCRIPTION
The showcase read_base package template neglects to call `super()`. This is probably because we don't want the 'Related' tab on the dataset nav bar. However, it has the consequence of making the extension incompatible with any other extension that also wants to extend the nav bar.

I will open an issue on ckan itself to make the 'Related' tab optional based on a config setting. That seems to me the cleanest option.
