### PR TITLE
Fix issue about add_ckan_admin_tab_plugin_notfound

### DIFF
--- a/ckanext/showcase/plugin.py
+++ b/ckanext/showcase/plugin.py
@@ -50,8 +50,7 @@ class ShowcasePlugin(plugins.SingletonPlugin, lib_plugins.DefaultDatasetForm):
     def update_config(self, config):
         tk.add_template_directory(config, 'templates')
         tk.add_public_directory(config, 'public')
-        # If ckan is more than 2.3, use the 2.4+ toolkit method
-        if not tk.check_ckan_version(max_version='2.3'):
+        if tk.check_ckan_version(min_version='2.4'):
             tk.add_ckan_admin_tab(config, 'ckanext_showcase_admins',
                                   'Showcase Config')
 


### PR DESCRIPTION
I check the minimal version required (2.4) instead of using negative logic. (related to #20)