### PR TITLE
Fix #31: Take site_url into account when loading CSS.

### DIFF
--- a/ckanext/showcase/templates/showcase/edit_base.html
+++ b/ckanext/showcase/templates/showcase/edit_base.html
@@ -6,7 +6,7 @@
 
 {% block styles %}
   {{ super() }}
-  <link rel="stylesheet" href="/ckanext_showcase.css" />
+  <link rel="stylesheet" href="{{ g.site_url }}/ckanext_showcase.css" />
 {% endblock %}
 
 {% block breadcrumb_content_selected %}{% endblock %}

--- a/ckanext/showcase/templates/showcase/read.html
+++ b/ckanext/showcase/templates/showcase/read.html
@@ -7,7 +7,7 @@
 
 {% block styles %}
   {{ super() }}
-  <link rel="stylesheet" href="/ckanext_showcase.css" />
+  <link rel="stylesheet" href="{{ g.site_url }}/ckanext_showcase.css" />
 {% endblock %}
 
 {% block links -%}


### PR DESCRIPTION
Fixes #31: Previously, it was tried to load CSS files from the server's root
directory. This fails if CKAN is running in a subdirectory.

With this change, the CSS file URLs are prefixed by CKAN's `site_url`
configuration setting.