### PR TITLE
Fix #34: search with nonascii filter queries

### DIFF
--- a/ckanext/showcase/plugin.py
+++ b/ckanext/showcase/plugin.py
@@ -248,10 +248,9 @@ class ShowcasePlugin(plugins.SingletonPlugin, lib_plugins.DefaultDatasetForm):
         `showcase`.
         '''
         fq = search_params.get('fq', '')
-        if 'dataset_type:{0}'.format(DATASET_TYPE_NAME) not in fq:
-            fq = "{0} -dataset_type:{1}".format(search_params.get('fq', ''),
-                                                DATASET_TYPE_NAME)
-            search_params.update({'fq': fq})
+        filter = 'dataset_type:{0}'.format(DATASET_TYPE_NAME)
+        if filter not in fq:
+            search_params.update({'fq': fq + " -" + filter})
         return search_params
 
     # ITranslation

--- a/ckanext/showcase/tests/test_plugin.py
+++ b/ckanext/showcase/tests/test_plugin.py
@@ -362,3 +362,19 @@ class TestShowcaseAdminManageView(helpers.FunctionalTestBase):
                            status=200, extra_environ=env)
 
         nosetools.assert_true('There are currently no Showcase Admins' in response)
+
+
+class TestSearch(helpers.FunctionalTestBase):
+
+    def test_search_with_nonascii_filter_query(self):
+        '''
+        Searching with non-ASCII filter queries works.
+
+        See https://github.com/ckan/ckanext-showcase/issues/34.
+        '''
+        app = self._get_test_app()
+        tag = u'\xe4\xf6\xfc'
+        dataset = factories.Dataset(tags=[{'name': tag, 'state': 'active'}])
+        result = helpers.call_action('package_search', fq='tags:' + tag)
+        nosetools.assert_equals(result['count'], 1)
+


### PR DESCRIPTION
This PR fixes #34.

The problem was that `before_search` implicitly assumed that the filter queries are pure ASCII (Python 2 `str`). However, if the filter queries contain non-ASCII characters then they are passed as `unicode` instances.

This PR refactors the code so that it works with both `str` and `unicode`. I've also added a corresponding test case.