### PR TITLE
[WIP] Move init logic in command

### DIFF
--- a/ckanext/showcase/commands/showcase.py
+++ b/ckanext/showcase/commands/showcase.py
@@ -3,16 +3,21 @@ from ckan.lib.cli import CkanCommand
 from ckan.lib.munge import munge_title_to_name, substitute_ascii_equivalents
 from ckan.logic import get_action
 
+from ckanext.showcase.model import setup as model_setup
+
 
 import logging
 log = logging.getLogger(__name__)
 
 
-class MigrationCommand(CkanCommand):
+class ShowcaseCommand(CkanCommand):
     '''
-    CKAN 'Related Items' to 'Showcase' migration command.
+    Commands for showcase extension
 
     Usage::
+
+        paster showcase init -c <path to config file>
+            - Initialize the extension, create tables
 
         paster showcase migrate -c <path to config file>
             - Migrate Related Items to Showcases
@@ -35,10 +40,14 @@ class MigrationCommand(CkanCommand):
 
         if cmd == 'migrate':
             self.migrate()
-        elif cmd == 'make_related':
-            self.make_related()
+        elif cmd == 'init':
+            self.init()
         else:
             print('Command "{0}" not recognized'.format(cmd))
+
+    def init(self):
+        print "Setup all tables"
+        model_setup()
 
     def migrate(self):
         '''

--- a/ckanext/showcase/plugin.py
+++ b/ckanext/showcase/plugin.py
@@ -18,7 +18,6 @@ import ckanext.showcase.logic.action.update
 import ckanext.showcase.logic.action.get
 import ckanext.showcase.logic.schema as showcase_schema
 import ckanext.showcase.logic.helpers as showcase_helpers
-from ckanext.showcase.model import setup as model_setup
 
 c = tk.c
 _ = tk._
@@ -29,7 +28,6 @@ DATASET_TYPE_NAME = 'showcase'
 
 
 class ShowcasePlugin(plugins.SingletonPlugin, lib_plugins.DefaultDatasetForm):
-    plugins.implements(plugins.IConfigurable)
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.IDatasetForm)
     plugins.implements(plugins.IFacets, inherit=True)
@@ -53,11 +51,6 @@ class ShowcasePlugin(plugins.SingletonPlugin, lib_plugins.DefaultDatasetForm):
         if tk.check_ckan_version(min_version='2.4'):
             tk.add_ckan_admin_tab(config, 'ckanext_showcase_admins',
                                   'Showcase Config')
-
-    # IConfigurable
-
-    def configure(self, config):
-        model_setup()
 
     # IDatasetForm
 

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
         ckan = ckan.lib.extract:extract_ckan
 
         [paste.paster_command]
-        showcase=ckanext.showcase.commands.migrate:MigrationCommand
+        showcase=ckanext.showcase.commands.showcase:ShowcaseCommand
     ''',
 
     message_extractors={


### PR DESCRIPTION
This solved #22, instead of always running the setup, this PR moves the logic to a new `init` command.