### PR TITLE
integrate force option for migration of relations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -134,11 +134,11 @@ From the ``ckanext-showcase`` directory::
     paster showcase migrate -c {path to production.ini}
 
 Note that each Related Item must have a unique title before migration can
-proceed. If you prefer resolving duplicates as showcases, you can use the force
+proceed. If you prefer resolving duplicates as showcases, you can use the --allow-duplicates
 option to migrate them anyways. Duplicate Relations will be created as
-'duplicate_' + original_related_title + '_' + hash
+'duplicate_' + original_related_title + '_' + related_dataset_id + '_' + hash
 
-    paster showcase migrate -c {path to production.ini} force
+    paster showcase migrate -c {path to production.ini} --allow-duplicates
 
 The Related Item property ``type`` will become a Showcase tag. The Related Item
 properties ``created``, ``owner_id``, ``view_count``, and ``featured`` have no

--- a/README.rst
+++ b/README.rst
@@ -134,7 +134,11 @@ From the ``ckanext-showcase`` directory::
     paster showcase migrate -c {path to production.ini}
 
 Note that each Related Item must have a unique title before migration can
-proceed.
+proceed. If you prefer resolving duplicates as showcases, you can use the force
+option to migrate them anyways. Duplicate Relations will be created as
+'duplicate_' + original_related_title + '_' + hash
+
+    paster showcase migrate -c {path to production.ini} force
 
 The Related Item property ``type`` will become a Showcase tag. The Related Item
 properties ``created``, ``owner_id``, ``view_count``, and ``featured`` have no

--- a/README.rst
+++ b/README.rst
@@ -136,7 +136,7 @@ From the ``ckanext-showcase`` directory::
 Note that each Related Item must have a unique title before migration can
 proceed. If you prefer resolving duplicates as showcases, you can use the --allow-duplicates
 option to migrate them anyways. Duplicate Relations will be created as
-'duplicate_' + original_related_title + '_' + related_dataset_id + '_' + hash
+'duplicate_' + original_related_title + '_' + related_id
 
     paster showcase migrate -c {path to production.ini} --allow-duplicates
 

--- a/ckanext/showcase/commands/migrate.py
+++ b/ckanext/showcase/commands/migrate.py
@@ -2,7 +2,6 @@ from ckan import model
 from ckan.lib.cli import CkanCommand
 from ckan.lib.munge import munge_title_to_name, substitute_ascii_equivalents
 from ckan.logic import get_action
-import uuid
 
 
 import logging
@@ -32,7 +31,7 @@ class MigrationCommand(CkanCommand):
         self.parser.add_option('--allow-duplicates', dest='allow_duplicates',
                             default=False, help='''Use this option to allow duplicate relations
                             to be migrated. Showcases will be created as
-                            'duplicate_related-name_package-name_uid'.''', action='store_true')
+                            'duplicate_related-name_package-name'.''', action='store_true')
 
     def command(self):
         '''
@@ -144,6 +143,6 @@ migration can continue. Please correct and try again:"""
         pkg_obj = model.Session.query(model.Package).filter_by(name=name).first()
         if pkg_obj:
             title.replace('duplicate_', '')
-            return 'duplicate_' + title + '_' + self._get_related_dataset(related_id) + '_' + str(uuid.uuid4())[:3]
+            return 'duplicate_' + title + '_' + related_id
         else:
             return title

--- a/ckanext/showcase/commands/migrate.py
+++ b/ckanext/showcase/commands/migrate.py
@@ -29,9 +29,10 @@ class MigrationCommand(CkanCommand):
         super(CkanCommand, self).__init__(name)
 
         self.parser.add_option('--allow-duplicates', dest='allow_duplicates',
-                            default=False, help='''Use this option to allow duplicate relations
-                            to be migrated. Showcases will be created as
-                            'duplicate_related-name_package-name'.''', action='store_true')
+                            default=False, help='''Use this option to allow
+                            related items with duplicate titles to be migrated.
+                            Duplicate showcases will be created as
+                            'duplicate_<related-name>_<related-id>'.''', action='store_true')
 
     def command(self):
         '''
@@ -48,8 +49,6 @@ class MigrationCommand(CkanCommand):
             self.migrate()
         elif cmd == 'make_related':
             self.make_related()
-        elif cmd == 'delete':
-            self.delete()
         else:
             print('Command "{0}" not recognized'.format(cmd))
 

--- a/ckanext/showcase/commands/migrate.py
+++ b/ckanext/showcase/commands/migrate.py
@@ -50,8 +50,7 @@ class MigrationCommand(CkanCommand):
         '''
         # determine wether migration should ignore duplicates
         try:
-            if self.args[1] == 'force':
-                force = True
+            force = (self.args[1] == 'force')
         except IndexError:
             force = False
 


### PR DESCRIPTION
I implemented the option to migrate relations to showcases when there are duplicate relations present.

You can append the 'force'-option to the original migrate command and it will create showcases as 

'duplicate_' + original_related_title + '_' + hash

That way you can resolve resulting issues as showcases, if you prefer it.