### PR TITLE
Showcase models should be setup for tests

### DIFF
--- a/ckanext/showcase/tests/__init__.py
+++ b/ckanext/showcase/tests/__init__.py
@@ -1,0 +1,16 @@
+from ckanext.showcase.model import setup as showcase_setup
+
+
+try:
+    import ckan.tests.helpers as helpers
+except ImportError:  # for ckan <= 2.3
+    import ckan.new_tests.helpers as helpers
+
+
+class ShowcaseFunctionalTestBase(helpers.FunctionalTestBase):
+
+    def setup(self):
+        '''Reset the database and clear the search indexes.'''
+        super(ShowcaseFunctionalTestBase, self).setup()
+        # set up showcase tables
+        showcase_setup()

--- a/ckanext/showcase/tests/action/test_create.py
+++ b/ckanext/showcase/tests/action/test_create.py
@@ -16,9 +16,10 @@ except ImportError:  # for ckan <= 2.3
 
 
 from ckanext.showcase.model import ShowcasePackageAssociation, ShowcaseAdmin
+from ckanext.showcase.tests import ShowcaseFunctionalTestBase
 
 
-class TestCreateShowcase(helpers.FunctionalTestBase):
+class TestCreateShowcase(ShowcaseFunctionalTestBase):
 
     def test_showcase_create_no_args(self):
         '''
@@ -78,7 +79,7 @@ class TestCreateShowcase(helpers.FunctionalTestBase):
                                .filter(Package.type == 'showcase').count(), 1)
 
 
-class TestCreateShowcasePackageAssociation(helpers.FunctionalTestBase):
+class TestCreateShowcasePackageAssociation(ShowcaseFunctionalTestBase):
 
     def test_association_create_no_args(self):
         '''
@@ -169,7 +170,7 @@ class TestCreateShowcasePackageAssociation(helpers.FunctionalTestBase):
                                 showcase_id=showcase_id)
 
 
-class TestCreateShowcaseAdmin(helpers.FunctionalTestBase):
+class TestCreateShowcaseAdmin(ShowcaseFunctionalTestBase):
 
     def test_showcase_admin_add_creates_showcase_admin_user(self):
         '''

--- a/ckanext/showcase/tests/action/test_delete.py
+++ b/ckanext/showcase/tests/action/test_delete.py
@@ -13,10 +13,11 @@ except ImportError:  # for ckan <= 2.3
     import ckan.new_tests.helpers as helpers
 
 from ckanext.showcase.model import ShowcasePackageAssociation, ShowcaseAdmin
+from ckanext.showcase.tests import ShowcaseFunctionalTestBase
 from ckan.model.package import Package
 
 
-class TestDeleteShowcase(helpers.FunctionalTestBase):
+class TestDeleteShowcase(ShowcaseFunctionalTestBase):
 
     def test_showcase_delete_no_args(self):
         '''
@@ -100,7 +101,7 @@ class TestDeleteShowcase(helpers.FunctionalTestBase):
         nosetools.assert_equal(model.Session.query(ShowcasePackageAssociation).count(), 0)
 
 
-class TestDeletePackage(helpers.FunctionalTestBase):
+class TestDeletePackage(ShowcaseFunctionalTestBase):
 
     def test_package_delete_retains_associations(self):
         '''
@@ -158,7 +159,7 @@ class TestDeletePackage(helpers.FunctionalTestBase):
         nosetools.assert_equal(model.Session.query(ShowcasePackageAssociation).count(), 1)
 
 
-class TestDeleteShowcasePackageAssociation(helpers.FunctionalTestBase):
+class TestDeleteShowcasePackageAssociation(ShowcaseFunctionalTestBase):
 
     def test_association_delete_no_args(self):
         '''
@@ -264,7 +265,7 @@ class TestDeleteShowcasePackageAssociation(helpers.FunctionalTestBase):
                                .filter(Package.type == 'showcase').count(), 1)
 
 
-class TestRemoveShowcaseAdmin(helpers.FunctionalTestBase):
+class TestRemoveShowcaseAdmin(ShowcaseFunctionalTestBase):
 
     def test_showcase_admin_remove_deletes_showcase_admin_user(self):
         '''

--- a/ckanext/showcase/tests/action/test_get.py
+++ b/ckanext/showcase/tests/action/test_get.py
@@ -12,8 +12,10 @@ try:
 except ImportError:  # for ckan <= 2.3
     import ckan.new_tests.helpers as helpers
 
+from ckanext.showcase.tests import ShowcaseFunctionalTestBase
 
-class TestShowcaseShow(helpers.FunctionalTestBase):
+
+class TestShowcaseShow(ShowcaseFunctionalTestBase):
 
     def test_showcase_show_no_args(self):
         '''
@@ -119,7 +121,7 @@ class TestShowcaseShow(helpers.FunctionalTestBase):
         nosetools.assert_equal(showcase_shown['num_datasets'], 2)
 
 
-class TestShowcaseList(helpers.FunctionalTestBase):
+class TestShowcaseList(ShowcaseFunctionalTestBase):
 
     def test_showcase_list(self):
         '''Showcase list action returns names of showcases in site.'''
@@ -158,7 +160,7 @@ class TestShowcaseList(helpers.FunctionalTestBase):
         nosetools.assert_true((dataset_two['name'], dataset_two['id']) not in showcase_list_name_id)
 
 
-class TestShowcasePackageList(helpers.FunctionalTestBase):
+class TestShowcasePackageList(ShowcaseFunctionalTestBase):
 
     '''Tests for ckanext_showcase_package_list'''
 
@@ -308,7 +310,7 @@ class TestShowcasePackageList(helpers.FunctionalTestBase):
                                 showcase_id=package['id'])
 
 
-class TestPackageShowcaseList(helpers.FunctionalTestBase):
+class TestPackageShowcaseList(ShowcaseFunctionalTestBase):
 
     '''Tests for ckanext_package_showcase_list'''
 
@@ -419,7 +421,7 @@ class TestPackageShowcaseList(helpers.FunctionalTestBase):
                                 package_id=showcase['id'])
 
 
-class TestShowcaseAdminList(helpers.FunctionalTestBase):
+class TestShowcaseAdminList(ShowcaseFunctionalTestBase):
 
     '''Tests for ckanext_showcase_admin_list'''
 
@@ -476,7 +478,7 @@ class TestShowcaseAdminList(helpers.FunctionalTestBase):
         nosetools.assert_true({'name': user_three['name'], 'id': user_three['id']} not in showcase_admin_list)
 
 
-class TestPackageSearchBeforeSearch(helpers.FunctionalTestBase):
+class TestPackageSearchBeforeSearch(ShowcaseFunctionalTestBase):
 
     '''
     Extension uses the `before_search` method to alter search parameters.
@@ -521,7 +523,7 @@ class TestPackageSearchBeforeSearch(helpers.FunctionalTestBase):
         nosetools.assert_true('dataset' not in types)
 
 
-class TestUserShowBeforeSearch(helpers.FunctionalTestBase):
+class TestUserShowBeforeSearch(ShowcaseFunctionalTestBase):
 
     '''
     Extension uses the `before_search` method to alter results of user_show

--- a/ckanext/showcase/tests/test_auth.py
+++ b/ckanext/showcase/tests/test_auth.py
@@ -12,8 +12,10 @@ try:
 except ImportError:  # for ckan <= 2.3
     import ckan.new_tests.helpers as helpers
 
+from ckanext.showcase.tests import ShowcaseFunctionalTestBase
 
-class TestShowcaseAuthIndex(helpers.FunctionalTestBase):
+
+class TestShowcaseAuthIndex(ShowcaseFunctionalTestBase):
 
     def test_auth_anon_user_can_view_showcase_index(self):
         '''An anon (not logged in) user can view the Showcases index.'''
@@ -73,7 +75,7 @@ class TestShowcaseAuthIndex(helpers.FunctionalTestBase):
         response.mustcontain("/showcase/new")
 
 
-class TestShowcaseAuthDetails(helpers.FunctionalTestBase):
+class TestShowcaseAuthDetails(ShowcaseFunctionalTestBase):
     def test_auth_anon_user_can_view_showcase_details(self):
         '''
         An anon (not logged in) user can view an individual Showcase details page.
@@ -190,7 +192,7 @@ class TestShowcaseAuthDetails(helpers.FunctionalTestBase):
         nosetools.assert_true(json_response['success'])
 
 
-class TestShowcaseAuthCreate(helpers.FunctionalTestBase):
+class TestShowcaseAuthCreate(ShowcaseFunctionalTestBase):
 
     def test_auth_anon_user_cant_view_create_showcase(self):
         '''
@@ -218,7 +220,7 @@ class TestShowcaseAuthCreate(helpers.FunctionalTestBase):
                 extra_environ={'REMOTE_USER': str(user['name'])})
 
 
-class TestShowcaseAuthList(helpers.FunctionalTestBase):
+class TestShowcaseAuthList(ShowcaseFunctionalTestBase):
 
     def test_auth_showcase_list_anon_can_access(self):
         '''
@@ -268,7 +270,7 @@ class TestShowcaseAuthList(helpers.FunctionalTestBase):
         nosetools.assert_true(json_response['success'])
 
 
-class TestShowcaseAuthEdit(helpers.FunctionalTestBase):
+class TestShowcaseAuthEdit(ShowcaseFunctionalTestBase):
 
     def test_auth_anon_user_cant_view_edit_showcase_page(self):
         '''
@@ -487,7 +489,7 @@ class TestShowcaseAuthEdit(helpers.FunctionalTestBase):
         nosetools.assert_true('showcase-add' in showcase_list_response.forms)
 
 
-class TestShowcasePackageAssociationCreate(helpers.FunctionalTestBase):
+class TestShowcasePackageAssociationCreate(ShowcaseFunctionalTestBase):
 
     def test_showcase_package_association_create_no_user(self):
         '''
@@ -537,7 +539,7 @@ class TestShowcasePackageAssociationCreate(helpers.FunctionalTestBase):
                                 context=context)
 
 
-class TestShowcasePackageAssociationDelete(helpers.FunctionalTestBase):
+class TestShowcasePackageAssociationDelete(ShowcaseFunctionalTestBase):
 
     def test_showcase_package_association_delete_no_user(self):
         '''
@@ -587,7 +589,7 @@ class TestShowcasePackageAssociationDelete(helpers.FunctionalTestBase):
                                 context=context)
 
 
-class TestShowcaseAdminAddAuth(helpers.FunctionalTestBase):
+class TestShowcaseAdminAddAuth(ShowcaseFunctionalTestBase):
 
     def test_showcase_admin_add_no_user(self):
         '''
@@ -618,7 +620,7 @@ class TestShowcaseAdminAddAuth(helpers.FunctionalTestBase):
                                 'ckanext_showcase_admin_add', context=context)
 
 
-class TestShowcaseAdminRemoveAuth(helpers.FunctionalTestBase):
+class TestShowcaseAdminRemoveAuth(ShowcaseFunctionalTestBase):
 
     def test_showcase_admin_remove_no_user(self):
         '''
@@ -649,7 +651,7 @@ class TestShowcaseAdminRemoveAuth(helpers.FunctionalTestBase):
                                 'ckanext_showcase_admin_remove', context=context)
 
 
-class TestShowcaseAdminListAuth(helpers.FunctionalTestBase):
+class TestShowcaseAdminListAuth(ShowcaseFunctionalTestBase):
 
     def test_showcase_admin_list_no_user(self):
         '''
@@ -680,7 +682,7 @@ class TestShowcaseAdminListAuth(helpers.FunctionalTestBase):
                                 'ckanext_showcase_admin_list', context=context)
 
 
-class TestShowcaseAuthManageShowcaseAdmins(helpers.FunctionalTestBase):
+class TestShowcaseAuthManageShowcaseAdmins(ShowcaseFunctionalTestBase):
 
     def test_auth_anon_user_cant_view_showcase_admin_manage_page(self):
         '''

--- a/ckanext/showcase/tests/test_converters.py
+++ b/ckanext/showcase/tests/test_converters.py
@@ -13,9 +13,10 @@ except ImportError:  # for ckan <= 2.3
     import ckan.new_tests.helpers as helpers
 
 from ckanext.showcase.logic.converters import convert_package_name_or_id_to_title_or_name
+from ckanext.showcase.tests import ShowcaseFunctionalTestBase
 
 
-class TestNameOrIdToTitleConverter(helpers.FunctionalTestBase):
+class TestNameOrIdToTitleConverter(ShowcaseFunctionalTestBase):
 
     def test_name_to_title(self):
         '''

--- a/ckanext/showcase/tests/test_helpers.py
+++ b/ckanext/showcase/tests/test_helpers.py
@@ -13,9 +13,10 @@ except ImportError:  # for ckan <= 2.3
     import ckan.new_tests.helpers as helpers
 
 import ckanext.showcase.logic.helpers as showcase_helpers
+from ckanext.showcase.tests import ShowcaseFunctionalTestBase
 
 
-class TestGetSiteStatistics(helpers.FunctionalTestBase):
+class TestGetSiteStatistics(ShowcaseFunctionalTestBase):
 
     def test_dataset_count_no_datasets(self):
         '''

--- a/ckanext/showcase/tests/test_plugin.py
+++ b/ckanext/showcase/tests/test_plugin.py
@@ -15,6 +15,7 @@ except ImportError:  # for ckan <= 2.3
     import ckan.new_tests.helpers as helpers
 
 from ckanext.showcase.model import ShowcasePackageAssociation
+from ckanext.showcase.tests import ShowcaseFunctionalTestBase
 
 import logging
 log = logging.getLogger(__name__)
@@ -22,7 +23,7 @@ log = logging.getLogger(__name__)
 submit_and_follow = helpers.submit_and_follow
 
 
-class TestShowcaseIndex(helpers.FunctionalTestBase):
+class TestShowcaseIndex(ShowcaseFunctionalTestBase):
 
     def test_showcases_redirects_to_showcase(self):
         '''/showcases redirects to /showcase.'''
@@ -52,7 +53,7 @@ class TestShowcaseIndex(helpers.FunctionalTestBase):
         response.mustcontain("my-showcase")
 
 
-class TestShowcaseNewView(helpers.FunctionalTestBase):
+class TestShowcaseNewView(ShowcaseFunctionalTestBase):
 
     def test_showcase_create_form_renders(self):
         app = self._get_test_app()
@@ -90,7 +91,7 @@ class TestShowcaseNewView(helpers.FunctionalTestBase):
                                        action='manage_datasets', id='my-showcase'), create_response.request.path)
 
 
-class TestShowcaseEditView(helpers.FunctionalTestBase):
+class TestShowcaseEditView(ShowcaseFunctionalTestBase):
 
     def test_showcase_edit_form_renders(self):
         '''
@@ -132,7 +133,7 @@ class TestShowcaseEditView(helpers.FunctionalTestBase):
                                        action='read', id='my-changed-showcase'), edit_response.request.path)
 
 
-class TestDatasetView(helpers.FunctionalTestBase):
+class TestDatasetView(ShowcaseFunctionalTestBase):
 
     '''Plugin adds a new showcases view for datasets.'''
 
@@ -289,7 +290,7 @@ class TestDatasetView(helpers.FunctionalTestBase):
         nosetools.assert_equal(model.Session.query(ShowcasePackageAssociation).count(), 0)
 
 
-class TestShowcaseAdminManageView(helpers.FunctionalTestBase):
+class TestShowcaseAdminManageView(ShowcaseFunctionalTestBase):
 
     '''Plugin adds a showcase admin management page to ckan-admin section.'''
 


### PR DESCRIPTION
Showcase model tables aren't always created when the tests run, resulting in errors during test setup. This creates a new `ShowcaseFunctionalTestBase` that explicitly sets up the model tables for each test.