### PR TITLE
Use convert_from_extras before ignore_missing

### DIFF
--- a/ckanext/showcase/logic/schema.py
+++ b/ckanext/showcase/logic/schema.py
@@ -104,11 +104,11 @@ def showcase_show_schema():
     schema['tracking_summary'] = []
 
     schema.update({
-        'image_url': [toolkit.get_validator('ignore_missing'),
-                      toolkit.get_converter('convert_from_extras')],
+        'image_url': [toolkit.get_converter('convert_from_extras'),
+                      toolkit.get_validator('ignore_missing')],
         'original_related_item_id': [
-            toolkit.get_validator('ignore_missing'),
-            toolkit.get_converter('convert_from_extras')],
+            toolkit.get_converter('convert_from_extras'),
+            toolkit.get_validator('ignore_missing')]
     })
 
     return schema


### PR DESCRIPTION
In the *_show schema the convert_from_extras converter should be placed
first, as at this point the field does not yet exist and with
ignore_missing the whole process is cancelled. Only if the order is like
that, we actually get a new field image_url as intended.

This is described here as well: http://docs.ckan.org/en/latest/extensions/adding-custom-fields.html#updating-the-ckan-schema

With the current code, this leads to the unfortunate situation, that one can upload an image to a showcase, but it is not displayed because the `image_url` field is not generated correctly, which subsequently does not generate the `image_display_url` field.

