### PR TITLE
except NotAuthorized when package can not be viewed

### DIFF
--- a/ckanext/showcase/logic/action/get.py
+++ b/ckanext/showcase/logic/action/get.py
@@ -3,6 +3,7 @@ import sqlalchemy
 import ckan.plugins.toolkit as toolkit
 import ckan.lib.dictization.model_dictize as model_dictize
 from ckan.lib.navl.dictization_functions import validate
+from ckan.logic import NotAuthorized
 
 from ckanext.showcase.logic.schema import (showcase_package_list_schema,
                                            package_showcase_list_schema)
@@ -78,10 +79,14 @@ def showcase_package_list(context, data_dict):
         # for each package id, get the package dict and append to list if
         # active
         for pkg_id in pkg_id_list:
-            pkg = toolkit.get_action('package_show')(context, {'id': pkg_id})
-            if pkg['state'] == 'active':
-                pkg_list.append(pkg)
-
+            try:
+                pkg = toolkit.get_action('package_show')(context,
+                                                         {'id': pkg_id})
+                if pkg['state'] == 'active':
+                    pkg_list.append(pkg)
+            except NotAuthorized:
+                log.error(
+                    'Not authorized to access Package with ID: ' + str(pkg_id))
     return pkg_list
 
 


### PR DESCRIPTION
when a showcase has an association with a deleted package the showcase-list-view can not be displayed as a not authorized user (not logged in)
this prevents the said dataset from being added to the view