### PR TITLE
Except NotAuthorized on Showcase-List

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,11 @@ Requirements
 
 Compatible with CKAN 2.3+.
 
+N.B. The ``migrate`` command, detailed below, requires the Related Item models
+and actions, which have been removed in CKAN 2.6. If you wish to migrate your
+Related Items, please first upgrade CKAN to 2.5, do the migration, then
+continue upgrading to CKAN 2.6+.
+
 
 ------------
 Installation


### PR DESCRIPTION
This fixes the issue, similar to https://github.com/ckan/ckanext-showcase/issues/41

When accessing the list of showcases, that are related to a certain package:
When one of the showcases has a relation to a deleted dataset, an error occurs. This PR uses the same approach like https://github.com/ckan/ckanext-showcase/pull/45 that already got merged.