### PR TITLE
Updating image style

### DIFF
--- a/ckanext/showcase/templates/showcase/snippets/showcase_item.html
+++ b/ckanext/showcase/templates/showcase/snippets/showcase_item.html
@@ -18,7 +18,7 @@ show_remove    - If True, show the remove button to remove showcase/dataset asso
 <li class="media-item">
   {% block item_inner %}
     {% block image %}
-      <img src="{{ package.image_display_url or h.url_for_static('/base/images/placeholder-group.png') }}" alt="{{ package.name }}" class="media-image">
+      <img src="{{ package.image_display_url or h.url_for_static('/base/images/placeholder-group.png') }}" alt="{{ package.name }}" class="media-image img-responsive">
     {% endblock %}
     {% block title %}
       <h3 class="media-heading">{{ h.link_to(h.truncate(title, truncate_title), h.url_for(controller='ckanext.showcase.controller:ShowcaseController', action='read', id=package.name)) }}</h3>


### PR DESCRIPTION
It seems that Showcase images look broken at Showcase tab on Dataset individual page.
Updated the styles by adding a new class as it was done here https://github.com/ckan/ckan/commit/927cb947 for **group.html**. This class adds responsive styles.