### PR TITLE
Fix templates

### DIFF
--- a/ckanext/showcase/templates/showcase/edit_base.html
+++ b/ckanext/showcase/templates/showcase/edit_base.html
@@ -24,7 +24,7 @@
 {% endblock %}
 
 {% block primary %}
-  <div class="primary {% block ckanext_showcase_edit_span %}span9{% endblock %}">
+  <div class="{% block ckanext_showcase_edit_span %}span12{% endblock %}">
     {% block primary_content %}
       <article class="module">
         {% block page_header %}

--- a/ckanext/showcase/templates/showcase/read.html
+++ b/ckanext/showcase/templates/showcase/read.html
@@ -63,7 +63,7 @@
     </h1>
 
     {% if pkg.image_display_url %}
-      <p class="ckanext-showcase-image-container"><img src="{{ pkg.image_display_url }}" alt="{{ name }}" class="media-image ckanext-showcase-image"></p>
+      <p class="ckanext-showcase-image-container"><img src="{{ pkg.image_display_url }}" alt="{{ name }}" class="media-image ckanext-showcase-image img-responsive"></p>
     {% endif %}
 
     {% block package_notes %}

--- a/ckanext/showcase/templates/showcase/snippets/showcase_item.html
+++ b/ckanext/showcase/templates/showcase/snippets/showcase_item.html
@@ -18,7 +18,7 @@ show_remove    - If True, show the remove button to remove showcase/dataset asso
 <li class="media-item">
   {% block item_inner %}
     {% block image %}
-      <img src="{{ package.image_display_url or h.url_for_static('/base/images/placeholder-group.png') }}" alt="{{ package.name }}" class="media-image">
+      <img src="{{ package.image_display_url or h.url_for_static('/base/images/placeholder-group.png') }}" alt="{{ package.name }}" class="media-image img-responsive">
     {% endblock %}
     {% block title %}
       <h3 class="media-heading">{{ h.link_to(h.truncate(title, truncate_title), h.url_for(controller='ckanext.showcase.controller:ShowcaseController', action='read', id=package.name)) }}</h3>


### PR DESCRIPTION
I noticed some small template issues: some images were not responsive, and the main column on the edit-showcase page was narrow and floating right. This PR fixes those.