### PR TITLE
Dataset-URLs on showcase-pages are broken

### DIFF
--- a/ckanext/showcase/templates/showcase/snippets/showcase_info.html
+++ b/ckanext/showcase/templates/showcase/snippets/showcase_info.html
@@ -40,7 +40,7 @@ Example:
         {% for package in showcase_pkgs %}
           {% set truncate_title = truncate_title or 80 %}
           {% set title = package.title or package.name %}
-          <li class="nav-item">{{ h.link_to(h.truncate(title, truncate_title), h.url_for(controller='package', action='read', id=package.name)) }}</li>
+          <li class="nav-item">{{ h.link_to(h.truncate(title, truncate_title), h.url_for(controller='dataset', action='read', id=package.name)) }}</li>
         {% endfor %}
         </ul>
       {% else %}


### PR DESCRIPTION
Using CKAN 2.8.2 we are having broken dataset-links on the detail page of a showcase. They create links like this:

/showcase?id=package-id

which doesn't make sense. Maybe this is a compatibility issue because of a newer CKAN version?

By using the dataset-controller we get directed to the connected dataset instead of redirecting to the showcase search-page searching for the dataset-id which is the functionality we are looking for.