### PR TITLE
change button-text to the action it is doing

### DIFF
--- a/ckanext/showcase/templates/package/dataset_showcase_list.html
+++ b/ckanext/showcase/templates/package/dataset_showcase_list.html
@@ -10,7 +10,7 @@
           <option value="{{ option[0] }}"> {{ option[1] }}</option>
         {% endfor %}
       </select>
-      <button type="submit" class="btn btn-primary" title="{{ _('Associate this showcase with this dataset') }}">{{ _('Add to showcase') }}</button>
+      <button type="submit" class="btn btn-primary" title="{{ _('Associate this showcase with this dataset') }}">{{ _('Add to dataset') }}</button>
     </form>
   {% endif %}
 


### PR DESCRIPTION
The button on the dataset page that adds showcases to a dataset is confusingly named 'Add to showcase' while it should be named the opposite.