### PR TITLE
fix query to display correct number of showcases

### DIFF
--- a/ckanext/showcase/logic/helpers.py
+++ b/ckanext/showcase/logic/helpers.py
@@ -21,7 +21,7 @@ def get_site_statistics():
 
     stats = {}
     stats['showcase_count'] = tk.get_action('package_search')(
-        {}, {"rows": 1, 'fq': 'dataset_type:showcase'})['count']
+        {}, {"rows": 1, 'fq': '+dataset_type:showcase'})['count']
     stats['dataset_count'] = tk.get_action('package_search')(
         {}, {"rows": 1, 'fq': '!dataset_type:showcase'})['count']
     stats['group_count'] = len(tk.get_action('group_list')({}, {}))


### PR DESCRIPTION
The statistics-snippet on the homepage displays the number of showcases on the portal.
The number seems to be the addition number of datasets + number of showcases. 
This fixes the query and displays the correct number for all entities.