### PR TITLE
Use package_search to get related showcase/package

### DIFF
--- a/ckanext/showcase/logic/action/get.py
+++ b/ckanext/showcase/logic/action/get.py
@@ -75,18 +75,17 @@ def showcase_package_list(context, data_dict):
         validated_data_dict['showcase_id'])
 
     pkg_list = []
-    if pkg_id_list is not None:
+    if pkg_id_list:
         # for each package id, get the package dict and append to list if
         # active
+        id_list = []
         for pkg_id in pkg_id_list:
-            try:
-                pkg = toolkit.get_action('package_show')(context,
-                                                         {'id': pkg_id})
-                if pkg['state'] == 'active':
-                    pkg_list.append(pkg)
-            except NotAuthorized:
-                log.debug(
-                    'Not authorized to access Package with ID: ' + str(pkg_id))
+            id_list.append(pkg_id[0])
+        q = ' OR '.join(['id:{0}'.format(x) for x in id_list])
+        _pkg_list = toolkit.get_action('package_search')(
+            context,
+            {'q': q, 'rows': 100})
+        pkg_list = _pkg_list['results']
     return pkg_list
 
 
@@ -113,19 +112,21 @@ def package_showcase_list(context, data_dict):
     # get a list of showcase ids associated with the package id
     showcase_id_list = ShowcasePackageAssociation.get_showcase_ids_for_package(
         validated_data_dict['package_id'])
-
     showcase_list = []
-    if showcase_id_list is not None:
+    # import ipdb; ipdb.sset_trace()
+    q = ''
+    fq = ''
+    if showcase_id_list:
+        id_list = []
         for showcase_id in showcase_id_list:
-            try:
-                showcase = toolkit.get_action('package_show')(
-                    context,
-                    {'id': showcase_id}
-                )
-                showcase_list.append(showcase)
-            except NotAuthorized:
-                log.debug('Not authorized to access Package with ID: '
-                          + str(showcase_id))
+            id_list.append(showcase_id[0])
+        fq = 'dataset_type:showcase'
+        q = ' OR '.join(['id:{0}'.format(x) for x in id_list])
+        _showcase_list = toolkit.get_action('package_search')(
+            context,
+            {'q': q, 'fq': fq, 'rows': 100})
+        showcase_list = _showcase_list['results']
+
     return showcase_list
 
 


### PR DESCRIPTION
Batch lookup for related showcases and packages.
This should offer a significant performance gain.

**note** I get the following (2) errors running tests locally -- these errors occur against master branch as well as my own branch:

```
======================================================================
ERROR: ckanext.showcase.tests.test_plugin.TestShowcaseEditView.test_showcase_edit_redirects_to_showcase_details
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/srv/app/src_extensions/ckanext-showcase/ckanext/showcase/tests/test_plugin.py", line 129, in test_showcase_edit_redirects_to_showcase_details
    edit_response = submit_and_follow(app, form, env, 'save')
  File "/srv/app/src/ckan/ckan/tests/helpers.py", line 280, in submit_and_follow
    extra_environ=extra_environ, **args)
  File "/srv/app/src/ckan/ckan/tests/helpers.py", line 301, in webtest_submit
    params=fields, **args)
  File "/usr/lib/python2.7/site-packages/webtest/app.py", line 369, in goto
    return method(href, **args)
  File "/usr/lib/python2.7/site-packages/webtest/app.py", line 838, in post
    content_type=content_type)
  File "/usr/lib/python2.7/site-packages/webtest/app.py", line 781, in _gen_request
    params, upload_files or ())
  File "/usr/lib/python2.7/site-packages/webtest/app.py", line 1000, in encode_multipart
    body = join_bytes('\r\n', lines)
  File "/usr/lib/python2.7/site-packages/webtest/compat.py", line 79, in join_bytes
    return sep.join(l)
TypeError: sequence item 43: expected string, NoneType found

======================================================================
ERROR: ckanext.showcase.tests.test_plugin.TestShowcaseNewView.test_showcase_new_redirects_to_manage_datasets
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/srv/app/src_extensions/ckanext-showcase/ckanext/showcase/tests/test_plugin.py", line 85, in test_showcase_new_redirects_to_manage_datasets
    create_response = submit_and_follow(app, form, env, 'save')
  File "/srv/app/src/ckan/ckan/tests/helpers.py", line 280, in submit_and_follow
    extra_environ=extra_environ, **args)
  File "/srv/app/src/ckan/ckan/tests/helpers.py", line 301, in webtest_submit
    params=fields, **args)
  File "/usr/lib/python2.7/site-packages/webtest/app.py", line 369, in goto
    return method(href, **args)
  File "/usr/lib/python2.7/site-packages/webtest/app.py", line 838, in post
    content_type=content_type)
  File "/usr/lib/python2.7/site-packages/webtest/app.py", line 781, in _gen_request
    params, upload_files or ())
  File "/usr/lib/python2.7/site-packages/webtest/app.py", line 1000, in encode_multipart
    body = join_bytes('\r\n', lines)
  File "/usr/lib/python2.7/site-packages/webtest/compat.py", line 79, in join_bytes
    return sep.join(l)
TypeError: sequence item 43: expected string, NoneType found

----------------------------------------------------------------------
Ran 142 tests in 75.837s

FAILED (errors=2)
```