### PR TITLE
Include webassets.yml in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include README.rst
-recursive-include ckanext/showcase *.html *.json *.js *.less *.css
+recursive-include ckanext/showcase/templates *
 recursive-include ckanext/showcase/i18n *
+recursive-include ckanext/showcase/fanstatic *


### PR DESCRIPTION
We need to include webassets.yml in the `MANIFEST.in` or it would not be included in the source install causing CKAN to not found the assets:

```
2021-03-31 17:29:54,687 ERROR [ckan.lib.webassets_tools] [Dummy-82] Trying to include unknown asset: <showcase/ckanext-showcase-css>
2021-03-31 17:29:54,782 ERROR [ckan.lib.webassets_tools] [Dummy-82] Trying to include unknown asset: <showcase/ckeditor>
```

Currently if we execute an install using something like:
```
pip install git+https://github.com/ckan/ckanext-showcase.git@v1.4.0#egg=ckanext-showcase
```

The resulting folder doesn't contain the `webasset.yml` file:
```
~$ ls /usr/local/lib/python2.7/dist-packages/ckanext/showcase/fanstatic/
ckanext_showcase.css  ckeditor-content-style.css  dist  js  src
```