### PR TITLE
Search Results Style: Use same tag than core

### DIFF
--- a/ckanext/showcase/templates/showcase/snippets/showcase_search_form.html
+++ b/ckanext/showcase/templates/showcase/snippets/showcase_search_form.html
@@ -2,6 +2,6 @@
 
 {% block search_title %}
 {% if not no_title %}
-  <h2>{% snippet 'showcase/snippets/showcase_search_result_text.html', query=query, count=count, type=type %}</h2>
+  <h1>{% snippet 'showcase/snippets/showcase_search_result_text.html', query=query, count=count, type=type %}</h1>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
Currently CKAN core has a `<h1>` tag to wrap-up the search result text: https://github.com/ckan/ckan/blob/3c4ae58969058b8c0a335a960010855ded5f3640/ckan/templates/snippets/search_form.html#L50

Using h1 instead of h2 will make CSS styling easier across extensions.