### PR TITLE
The manage datasets route name was hardcoded

### DIFF
--- a/ckanext/showcase/templates/showcase/confirm_delete.html
+++ b/ckanext/showcase/templates/showcase/confirm_delete.html
@@ -2,6 +2,9 @@
 
 {% set pkg = pkg_dict or c.pkg_dict %}
 
+{% set ckan_29_or_higher = h.ckan_version().split('.')[1] | int >= 9 %}
+{% set showcase_delete_route = 'showcase_blueprint.delete' if ckan_29_or_higher else 'showcase_delete' %}
+
 {% block subtitle %}{{ _("Confirm Delete") }}{% endblock %}
 
 {% block maintag %}
@@ -14,7 +17,7 @@
             {% block form %}
                 <p>{{ _('Are you sure you want to delete showcase - {showcase_name}?').format(showcase_name=pkg.name) }}</p>
                 <p class="form-actions">
-                    <form action="{{ h.url_for('showcase_delete', id=c.pkg_dict.name) }}" method="post">
+                    <form action="{{ h.url_for(showcase_delete_route, id=c.pkg_dict.name) }}" method="post">
                         <button class="btn" type="submit" name="cancel" >{{ _('Cancel') }}</button>
                         <button class="btn btn-primary" type="submit" name="delete" >{{ _('Confirm Delete') }}</button>
                     </form>

--- a/ckanext/showcase/utils.py
+++ b/ckanext/showcase/utils.py
@@ -124,6 +124,11 @@ def manage_datasets_view(id):
     form_data = tk.request.form if tk.check_ckan_version(
         '2.9') else tk.request.params
 
+    if tk.check_ckan_version(min_version='2.9.0'):
+        manage_route = 'showcase_blueprint.manage_datasets'
+    else:
+        manage_route = 'showcase_manage_datasets'
+    
     if (tk.request.method == 'POST'
             and 'bulk_action.showcase_remove' in form_data):
         # Find the datasets to perform the action on, they are prefixed by
@@ -144,7 +149,7 @@ def manage_datasets_view(id):
                     "The dataset has been removed from the showcase.",
                     "The datasets have been removed from the showcase.",
                     len(dataset_ids)))
-            url = h.url_for('showcase_manage_datasets', id=id)
+            url = h.url_for(manage_route, id=id)
             return h.redirect_to(url)
 
     # Are we creating a showcase/dataset association?
@@ -176,7 +181,7 @@ def manage_datasets_view(id):
                         "The dataset has been added to the showcase.",
                         "The datasets have been added to the showcase.",
                         len(successful_adds)))
-            url = h.url_for('showcase_manage_datasets', id=id)
+            url = h.url_for(manage_route, id=id)
             return h.redirect_to(url)
 
     _add_dataset_search(tk.c.pkg_dict['id'], tk.c.pkg_dict['name'])


### PR DESCRIPTION
The manage datasets route name was hardcoded to the PRE-2.9 name
The delete showcase route name was hardcoded to the PRE-2.9 name