### PR TITLE
repair logic 'showcase_package_list'

### DIFF
--- a/ckanext/showcase/logic/action/get.py
+++ b/ckanext/showcase/logic/action/get.py
@@ -81,7 +81,7 @@ def showcase_package_list(context, data_dict):
         id_list = []
         for pkg_id in pkg_id_list:
             id_list.append(pkg_id[0])
-        q = ' OR '.join(['id:{0}'.format(x) for x in id_list])
+        q = 'id:(' + ' OR '.join(['{0}'.format(x) for x in id_list]) + ')'
         _pkg_list = toolkit.get_action('package_search')(
             context,
             {'q': q, 'rows': 100})


### PR DESCRIPTION
the solr logic for more that one showcase ids should be
fq=id:(id1 OR id2 ...) instead of fq=id:id1 OR id2