### PR TITLE
Fix tags facets not being displayed on index page

### DIFF
--- a/ckanext/showcase/templates/showcase/search.html
+++ b/ckanext/showcase/templates/showcase/search.html
@@ -46,12 +46,5 @@
 
 {% block secondary_content %}
 {{ h.snippet('showcase/snippets/helper.html') }}
-<div class="filters">
-  <div>
-    {% for facet in c.facet_titles %}
-      {{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet) }}
-    {% endfor %}
-  </div>
-  <a class="close no-text hide-filters"><i class="fa fa-times-circle icon-remove-sign"></i><span class="text">close</span></a>
-</div>
+{{ super() }}
 {% endblock %}

--- a/ckanext/showcase/tests/test_plugin.py
+++ b/ckanext/showcase/tests/test_plugin.py
@@ -29,6 +29,16 @@ class TestShowcaseIndex(object):
         assert "1 showcase found" in response.body
         assert "my-showcase" in response.body
 
+    def test_tags_facets_are_being_shown(self, app):
+        factories.Dataset(
+            type="showcase", 
+            name="my-showcase",
+            tags=[{"name": "this-must-be-shown"}]
+            )
+
+        response = app.get("/showcase", status=200)
+        assert '<span class="item-label">this-must-be-shown</span>' in response.body
+
 
 @pytest.mark.usefixtures("clean_db")
 class TestShowcaseNewView(object):


### PR DESCRIPTION
Tags are not being shown in the index view of showcases.

This PR fixes the issue and adds a test for it.