### PR TITLE
add compatibility table to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,11 +26,14 @@ ckanext-showcase is intended to be a more powerful replacement for the
 'Related Item' feature.
 
 
-------------
-Requirements
-------------
+-------------
+Compatibility
+-------------
 
-Tested on CKAN 2.7 to 2.10..
+| ckanext-showcase | CKAN      |
+|------------------|-----------|
+| 1.4              | 2.7 - 2.9 |
+| 1.5              | 2.10      |
 
 ------------
 Installation


### PR DESCRIPTION
I faced an error like the following trying to use version 1.5 of the extension in my CKAN 2.9 installation:

```
Traceback (most recent call last):
  File "/opt/ckan/venv/lib/python3.8/site-packages/flask/app.py", line 1949, in full_dispatch_request
    rv = self.dispatch_request()
  File "/opt/ckan/venv/lib/python3.8/site-packages/flask/app.py", line 1935, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/opt/ckan/venv/lib/python3.8/site-packages/flask/views.py", line 89, in view
    return self.dispatch_request(*args, **kwargs)
  File "/opt/ckan/venv/lib/python3.8/site-packages/flask/views.py", line 163, in dispatch_request
    return meth(*args, **kwargs)
  File "/opt/ckan/venv/lib/python3.8/site-packages/ckanext/showcase/views.py", line 73, in post
    context = self._prepare()
TypeError: _prepare() missing 1 required positional argument: 'id'
```

The change introduced in 19aaaf48 and published as part of version `1.5` renders the extension incompatible with CKAN 2.9 and previous. This table will help people install the appropiate version of the extension for their projects.

Perhaps a line in `install_requires` asking for CKAN 2.10 would prevent this error from ever happening.