### PR TITLE
fix: bug regarding visibility on the showcase detail page

### DIFF
--- a/ckanext/showcase/templates/showcase/read.html
+++ b/ckanext/showcase/templates/showcase/read.html
@@ -58,7 +58,7 @@
     {% endif %}
     {% block package_description %}
         {% if pkg.private == 'True' %}
-            <span class="dataset-private label label-inverse pull-right">
+            <span class="dataset-private label label-inverse">
                 <i class="fa fa-lock icon-lock"></i>
                 {{ _('Private') }}
             </span>

--- a/ckanext/showcase/templates/showcase/read.html
+++ b/ckanext/showcase/templates/showcase/read.html
@@ -57,7 +57,7 @@
         </div>
     {% endif %}
     {% block package_description %}
-        {% if pkg.private %}
+        {% if pkg.private == 'True' %}
             <span class="dataset-private label label-inverse pull-right">
                 <i class="fa fa-lock icon-lock"></i>
                 {{ _('Private') }}


### PR DESCRIPTION
the pkg.private field is set to be a string of either "True" or "False". So for private datasets pkg.private must be compared to "True"

This fixes: https://github.com/ckan/ckanext-showcase/issues/150