### PR TITLE
String prefix cleanup

### DIFF
--- a/ckanext/showcase/plugin.py
+++ b/ckanext/showcase/plugin.py
@@ -125,9 +125,7 @@ class ShowcasePlugin(plugins.SingletonPlugin, lib_plugins.DefaultDatasetForm):
     # IPackageController
 
     def _add_to_pkg_dict(self, context, pkg_dict):
-        '''
-        Add key/values to pkg_dict and return it.
-        '''
+        '''Add key/values to pkg_dict and return it.'''
 
         if pkg_dict['type'] != 'showcase':
             return pkg_dict
@@ -135,40 +133,36 @@ class ShowcasePlugin(plugins.SingletonPlugin, lib_plugins.DefaultDatasetForm):
         # Add a display url for the Showcase image to the pkg dict so template
         # has access to it.
         image_url = pkg_dict.get('image_url')
-        pkg_dict[u'image_display_url'] = image_url
+        pkg_dict['image_display_url'] = image_url
         if image_url and not image_url.startswith('http'):
-            pkg_dict[u'image_url'] = image_url
-            pkg_dict[u'image_display_url'] = \
+            pkg_dict['image_url'] = image_url
+            pkg_dict['image_display_url'] = \
                 h.url_for_static('uploads/{0}/{1}'
                                  .format(DATASET_TYPE_NAME,
                                          pkg_dict.get('image_url')),
                                  qualified=True)
 
         # Add dataset count
-        pkg_dict[u'num_datasets'] = len(
+        pkg_dict['num_datasets'] = len(
             tk.get_action('ckanext_showcase_package_list')(
                 context, {'showcase_id': pkg_dict['id']}))
 
         # Rendered notes
         if showcase_helpers.showcase_get_wysiwyg_editor() == 'ckeditor':
-            pkg_dict[u'showcase_notes_formatted'] = pkg_dict['notes']
+            pkg_dict['showcase_notes_formatted'] = pkg_dict['notes']
         else:
-            pkg_dict[u'showcase_notes_formatted'] = \
+            pkg_dict['showcase_notes_formatted'] = \
                 h.render_markdown(pkg_dict['notes'])
 
         return pkg_dict
 
     # CKAN >= 2.10
     def after_dataset_show(self, context, pkg_dict):
-        '''
-        Modify package_show pkg_dict.
-        '''
+        '''Modify package_show pkg_dict.'''
         pkg_dict = self._add_to_pkg_dict(context, pkg_dict)
 
     def before_dataset_view(self, pkg_dict):
-        '''
-        Modify pkg_dict that is sent to templates.
-        '''
+        '''Modify pkg_dict that is sent to templates.'''
         context = {'user': tk.g.user or tk.g.author}
 
         return self._add_to_pkg_dict(context, pkg_dict)
@@ -187,15 +181,11 @@ class ShowcasePlugin(plugins.SingletonPlugin, lib_plugins.DefaultDatasetForm):
 
     # CKAN < 2.10 (Remove when dropping support for 2.9)
     def after_show(self, context, pkg_dict):
-        '''
-        Modify package_show pkg_dict.
-        '''
+        '''Modify package_show pkg_dict.'''
         pkg_dict = self.after_dataset_show(context, pkg_dict)
 
     def before_view(self, pkg_dict):
-        '''
-        Modify pkg_dict that is sent to templates.
-        '''
+        '''Modify pkg_dict that is sent to templates.'''
         return self.before_dataset_view(pkg_dict)
 
     def before_search(self, search_params):

--- a/ckanext/showcase/utils.py
+++ b/ckanext/showcase/utils.py
@@ -195,7 +195,7 @@ def _add_dataset_search(showcase_id, showcase_name):
     package_type = 'dataset'
 
     # unicode format (decoded from utf8)
-    q = tk.g.q = tk.request.args.get('q', u'')
+    q = tk.g.q = tk.request.args.get('q', '')
     tk.g.query_error = False
     page = h.get_page_number(tk.request.args)
 
@@ -389,7 +389,7 @@ def _encode_params(params):
 
 def url_with_params(url, params):
     params = _encode_params(params)
-    return url + u'?' + urlencode(params)
+    return url + '?' + urlencode(params)
 
 
 def delete_view(id):

--- a/ckanext/showcase/views.py
+++ b/ckanext/showcase/views.py
@@ -9,7 +9,7 @@ import ckan.views.dataset as dataset
 
 import ckanext.showcase.utils as utils
 
-showcase = Blueprint(u'showcase_blueprint', __name__)
+showcase = Blueprint('showcase_blueprint', __name__)
 
 
 def index():
@@ -122,32 +122,32 @@ showcase.add_url_rule('/showcase', view_func=index, endpoint="index")
 showcase.add_url_rule('/showcase/new', view_func=CreateView.as_view('new'), endpoint="new")
 showcase.add_url_rule('/showcase/delete/<id>',
                       view_func=delete,
-                      methods=[u'GET', u'POST'],
+                      methods=['GET', 'POST'],
                       endpoint="delete")
 showcase.add_url_rule('/showcase/<id>', view_func=read, endpoint="read")
 showcase.add_url_rule('/showcase/edit/<id>',
                       view_func=EditView.as_view('edit'),
-                      methods=[u'GET', u'POST'],
+                      methods=['GET', 'POST'],
                       endpoint="edit")
 showcase.add_url_rule('/showcase/manage_datasets/<id>',
                       view_func=manage_datasets,
-                      methods=[u'GET', u'POST'],
+                      methods=['GET', 'POST'],
                       endpoint="manage_datasets")
 showcase.add_url_rule('/dataset/showcases/<id>',
                       view_func=dataset_showcase_list,
-                      methods=[u'GET', u'POST'],
+                      methods=['GET', 'POST'],
                       endpoint="dataset_showcase_list")
 showcase.add_url_rule('/ckan-admin/showcase_admins',
                       view_func=admins,
-                      methods=[u'GET', u'POST'],
+                      methods=['GET', 'POST'],
                       endpoint="admins")
 showcase.add_url_rule('/ckan-admin/showcase_admin_remove',
                       view_func=admin_remove,
-                      methods=[u'GET', u'POST'],
+                      methods=['GET', 'POST'],
                       endpoint='admin_remove')
 showcase.add_url_rule('/showcase_upload',
                       view_func=upload,
-                      methods=[u'POST'])
+                      methods=['POST'])
 
 
 def get_blueprints():

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
 
 pytest_plugins = [
-    u'ckanext.showcase.tests.fixtures',
+    'ckanext.showcase.tests.fixtures',
 ]


### PR DESCRIPTION
This is just a small PR to clean up all the remaining string prefix: `u'`.