### PR TITLE
Fixes delete and update showcase buttons

### DIFF
--- a/ckanext/showcase/templates/showcase/new_package_form.html
+++ b/ckanext/showcase/templates/showcase/new_package_form.html
@@ -1,6 +1,6 @@
 {% import 'macros/form.html' as form %}
-{% set action = c.form_action or '' %}
-{% set form_style = c.form_style or c.action %}
+{% set action = form_action or '' %}
+{% set form_style = form_style or action %}
 {% set showcase_read_route = 'showcase_blueprint.read' %}
 {% set showcase_delete_route = 'showcase_blueprint.delete' %}
 


### PR DESCRIPTION
Currently, `c.form_action` and `c.form_style` do not return anything.
This means that the logic for displaying the `delete` and `update` buttons will not work.
Refactored code to avoid using `c.` to assign `action` and `form_style` variables.