### PR TITLE
Update MANIFEST.in to include migration files and public assets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,13 +17,14 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        ckan-version: ["2.11", "2.10", 2.9]
+        ckan-version: ["2.11", "2.10"]
       fail-fast: false
 
     name: CKAN ${{ matrix.ckan-version }}
     runs-on: ubuntu-latest
     container:
       image: ckan/ckan-dev:${{ matrix.ckan-version }}
+      options: --user root
     services:
       solr:
         image: ckan/ckan-solr:${{ matrix.ckan-version }}-solr9
@@ -52,9 +53,11 @@ jobs:
         pip install -e .
         # Replace default path to CKAN core config file with the one on the container
         sed -i -e 's/use = config:.*/use = config:\/srv\/app\/src\/ckan\/test-core.ini/' test.ini
+
     - name: Setup extension (CKAN >= 2.9)
       run: |
         ckan -c test.ini db init
+
     - name: Run tests
       run: pytest --ckan-ini=test.ini --cov=ckanext.showcase --cov-report=term-missing --cov-append --disable-warnings ckanext/showcase/tests
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,5 @@ include README.rst
 recursive-include ckanext/showcase/templates *
 recursive-include ckanext/showcase/i18n *
 recursive-include ckanext/showcase/fanstatic *
+recursive-include ckanext/showcase/migration *.ini *.py *.mako
+recursive-include ckanext/showcase/public *.*

--- a/setup.py
+++ b/setup.py
@@ -48,8 +48,7 @@ setup(
 
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
-    namespace_packages=['ckanext'],
+    packages=find_packages(include=['ckanext', 'ckanext.*']),
 
     # List run-time dependencies here.  These will be installed by pip when your
     # project is installed. For an analysis of "install_requires" vs pip's


### PR DESCRIPTION
If possible, please release a new tag/version

Test for CKAN 2.9 started failing due to a setptools conflicts
After fixing that, a solr9 schema error appears
The tests were divided into two files

A new approach with lates version only compatible with latest CKAN and older version branches here compatible with older CKAN version will dramatically reduce times for PRs here.
It's always possible to backport new features for older version branches
