### PR TITLE
Clean up c object

### DIFF
--- a/ckanext/showcase/templates/admin/confirm_remove_showcase_admin.html
+++ b/ckanext/showcase/templates/admin/confirm_remove_showcase_admin.html
@@ -9,11 +9,11 @@
   <section class="module span6 offset3">
     <div class="module-content">
       {% block form %}
-        <p>{{ _('Are you sure you want to remove this user as a Showcase Admin - {name}?').format(name=c.user_dict.name) }}</p>
+        <p>{{ _('Are you sure you want to remove this user as a Showcase Admin - {name}?').format(name=user_dict.name) }}</p>
         <p class="form-actions">
             <form action="{{ h.url_for(showcase_admin_remove_route) }}" method="post">
             {{ h.csrf_input() if 'csrf_input' in h }}
-            <input type="hidden" name="user" value="{{ c.user_id }}" />
+            <input type="hidden" name="user" value="{{ user_id }}" />
             <button class="btn" type="submit" name="cancel" >{{ _('Cancel') }}</button>
             <button class="btn btn-primary" type="submit" name="delete" >{{ _('Confirm Remove') }}</button>
           </form>

--- a/ckanext/showcase/templates/admin/manage_showcase_admins.html
+++ b/ckanext/showcase/templates/admin/manage_showcase_admins.html
@@ -2,7 +2,7 @@
 
 {% import 'macros/form.html' as form %}
 
-{% set user = c.user_dict %}
+{% set user = user_dict %}
 {% set showcase_admin_remove_route = 'showcase_blueprint.admin_remove' %}
 
 
@@ -39,7 +39,7 @@
   {% endblock %}
 
   <h3 class="page-heading">{{ _('Showcase Admins') }}</h3>
-  {% if c.showcase_admins %}
+  {% if showcase_admins %}
   <table class="table table-header table-hover table-bordered">
     <thead>
       <tr>
@@ -47,7 +47,7 @@
       </tr>
     </thead>
     <tbody>
-      {% for user_dict in c.showcase_admins %}
+      {% for user_dict in showcase_admins %}
       <tr>
         <td class="media">
           {{ h.linked_user(user_dict['id'], maxlength=20) }}

--- a/ckanext/showcase/templates/package/dataset_showcase_list.html
+++ b/ckanext/showcase/templates/package/dataset_showcase_list.html
@@ -3,11 +3,11 @@
 {% block subtitle %}{{ _('Showcases') }} - {{ super() }}{% endblock %}
 
 {% block primary_content_inner %}
-    {% if h.check_access('ckanext_showcase_update') and c.showcase_dropdown %}
+    {% if h.check_access('ckanext_showcase_update') and showcase_dropdown %}
         <form method="post" class="form-horizontal" id="showcase-add">
             {{ h.csrf_input() if 'csrf_input' in h }}
             <select id="field-add_showcase" name="showcase_added" data-module="autocomplete">
-                {% for option in c.showcase_dropdown %}
+                {% for option in showcase_dropdown %}
                     <option value="{{ option[0] }}"> {{ option[1] }}</option>
                 {% endfor %}
             </select>
@@ -15,10 +15,10 @@
         </form>
     {% endif %}
 
-    <h2>{% block page_heading %}{{ _('Showcases featuring {dataset_name}').format(dataset_name=h.dataset_display_name(c.pkg_dict)) }}{% endblock %}</h2>
+    <h2>{% block page_heading %}{{ _('Showcases featuring {dataset_name}').format(dataset_name=h.dataset_display_name(pkg_dict)) }}{% endblock %}</h2>
     {% block showcase_list %}
-        {% if c.showcase_list %}
-            {% snippet "showcase/snippets/showcase_list.html", packages=c.showcase_list, pkg_id=c.pkg_dict.name, show_remove=h.check_access('ckanext_showcase_update') %}
+        {% if showcase_list %}
+            {% snippet "showcase/snippets/showcase_list.html", packages=showcase_list, pkg_id=pkg_dict.name, show_remove=h.check_access('ckanext_showcase_update') %}
         {% else %}
             <p class="empty">{{ _('There are no showcases that feature this dataset') }}</p>
         {% endif %}

--- a/ckanext/showcase/templates/showcase/add_datasets.html
+++ b/ckanext/showcase/templates/showcase/add_datasets.html
@@ -11,11 +11,11 @@
     <div class="module-content">
       {% block form %}
         {% set facets = {
-          'fields': c.fields_grouped,
-          'search': c.search_facets,
-          'titles': c.facet_titles,
-          'translated_fields': c.translated_fields,
-          'remove_field': c.remove_field }
+          'fields': fields_grouped,
+          'search': search_facets,
+          'titles': facet_titles,
+          'translated_fields': translated_fields,
+          'remove_field': remove_field }
         %}
         {% set sorting = [
           (_('Relevance'), 'score desc, metadata_modified desc'),
@@ -24,7 +24,7 @@
           (_('Last Modified'), 'metadata_modified desc'),
           (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ]
         %}
-        {% snippet 'snippets/search_form.html', type='dataset', query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, facets=facets, show_empty=request.args, error=c.query_error, fields=c.fields %}
+        {% snippet 'snippets/search_form.html', type='dataset', query=q, sorting=sorting, sorting_selected=sort_by_selected, count=page.item_count, facets=facets, show_empty=request.args, error=query_error, fields=fields %}
       {% endblock %}
        <h3 class="page-heading">
         {% block page_heading %}
@@ -32,7 +32,7 @@
         {% endblock %}
       </h3>
       {% block package_search_results_list %}
-        {% if c.page.items %}
+        {% if page.items %}
           <form method="POST" data-module="basic-form">
             {{ h.csrf_input() if 'csrf_input' in h }}
             {#{% block errors %}{{ form.errors(error_summary) }}{% endblock %}#}
@@ -53,7 +53,7 @@
                 </tr>
               </thead>
               <tbody>
-                {% for package in c.page.items %}
+                {% for package in page.items %}
                   {% set truncate = truncate or 180 %}
                   {% set truncate_title = truncate_title or 80 %}
                   {% set title = package.title or package.name %}
@@ -82,7 +82,7 @@
     </div>
 
     {% block page_pagination %}
-      {{ c.page.pager(q=c.q) }}
+      {{ page.pager(q=q) }}
     {% endblock %}
   </section>
 

--- a/ckanext/showcase/templates/showcase/confirm_delete.html
+++ b/ckanext/showcase/templates/showcase/confirm_delete.html
@@ -1,6 +1,6 @@
 {% extends "page.html" %}
 
-{% set pkg = pkg_dict or c.pkg_dict %}
+{% set pkg = pkg_dict %}
 {% set showcase_delete_route = 'showcase_blueprint.delete' %}
 
 {% block subtitle %}{{ _("Confirm Delete") }}{% endblock %}
@@ -15,7 +15,7 @@
             {% block form %}
                 <p>{{ _('Are you sure you want to delete showcase - {showcase_name}?').format(showcase_name=pkg.name) }}</p>
                 <p class="form-actions">
-                    <form action="{{ h.url_for(showcase_delete_route, id=c.pkg_dict.name) }}" method="post">
+                    <form action="{{ h.url_for(showcase_delete_route, id=pkg_dict.name) }}" method="post">
                         {{ h.csrf_input() if 'csrf_input' in h }}
                         <button class="btn" type="submit" name="cancel" >{{ _('Cancel') }}</button>
                         <button class="btn btn-primary" type="submit" name="delete" >{{ _('Confirm Delete') }}</button>

--- a/ckanext/showcase/templates/showcase/edit_base.html
+++ b/ckanext/showcase/templates/showcase/edit_base.html
@@ -1,6 +1,6 @@
 {% extends 'page.html' %}
 
-{% set pkg = pkg_dict or c.pkg_dict  %}
+{% set pkg = pkg_dict  %}
 
 {% set showcase_index_route = 'showcase_blueprint.index' %}
 {% set showcase_read_route = 'showcase_blueprint.read' %}

--- a/ckanext/showcase/templates/showcase/manage_datasets.html
+++ b/ckanext/showcase/templates/showcase/manage_datasets.html
@@ -14,11 +14,11 @@
 
     <div class="module-content">
       {% set facets = {
-        'fields': c.fields_grouped,
-        'search': c.search_facets,
-        'titles': c.facet_titles,
-        'translated_fields': c.translated_fields,
-        'remove_field': c.remove_field }
+        'fields': fields_grouped,
+        'search': search_facets,
+        'titles': facet_titles,
+        'translated_fields': translated_fields,
+        'remove_field': remove_field }
       %}
       {% set sorting = [
         (_('Relevance'), 'score desc, metadata_modified desc'),
@@ -27,7 +27,7 @@
         (_('Last Modified'), 'metadata_modified desc'),
         (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ]
       %}
-      {% snippet 'snippets/search_form.html', type='dataset', query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, facets=facets, show_empty=request.args, error=c.query_error, fields=c.fields %}
+      {% snippet 'snippets/search_form.html', type='dataset', query=q, sorting=sorting, sorting_selected=sort_by_selected, count=page.item_count, facets=facets, show_empty=request.args, error=query_error, fields=fields %}
     </div>
 
     <div class="row row2">
@@ -35,7 +35,7 @@
         <div class="module-content">
           <h3 class="page-heading">{{ _('Datasets available to add to this showcase') }}</h3>
           {% block package_search_results_list %}
-            {% if c.page.items %}
+            {% if page.items %}
               <form method="POST" data-module="basic-form">
                 {{ h.csrf_input() if 'csrf_input' in h }}
                 {#{% block errors %}{{ form.errors(error_summary) }}{% endblock %}#}
@@ -56,7 +56,7 @@
                     </tr>
                   </thead>
                   <tbody>
-                    {% for package in c.page.items %}
+                    {% for package in page.items %}
                       {% set truncate = truncate or 180 %}
                       {% set truncate_title = truncate_title or 80 %}
                       {% set title = package.title or package.name %}
@@ -76,10 +76,10 @@
                       </tr>
                     {% endfor %}
                   </tbody>
-                  {% if c.page.pager() %}
+                  {% if page.pager() %}
                       <tfoot>
                           <tr>
-                              <td colspan="2" class="ckanext_showcase_pagination_footer">{{ c.page.pager(q=c.q) }}</td>
+                              <td colspan="2" class="ckanext_showcase_pagination_footer">{{ page.pager(q=q) }}</td>
                           </tr>
                       </tfoot>
                   {% endif %}
@@ -95,7 +95,7 @@
       <section class="span6">
           <div class="module-content">
               <h3 class="page-heading">{{ _('Datasets in this showcase') }}</h3>
-              {% if c.showcase_pkgs %}
+              {% if showcase_pkgs %}
                   <form method="POST" data-module="basic-form">
                     {{ h.csrf_input() if 'csrf_input' in h }}
                       <table class="table table-bordered table-header table-hover table-bulk-edit table-edit-hover" data-module="table-selectable-rows">
@@ -115,7 +115,7 @@
                               </tr>
                           </thead>
                           <tbody>
-                              {% for package in c.showcase_pkgs %}
+                              {% for package in showcase_pkgs %}
                                   {% set truncate = truncate or 180 %}
                                   {% set truncate_title = truncate_title or 80 %}
                                   {% set title = package.title or package.name %}

--- a/ckanext/showcase/templates/showcase/read.html
+++ b/ckanext/showcase/templates/showcase/read.html
@@ -1,6 +1,6 @@
 {% extends "page.html" %}
 
-{% set pkg = pkg_dict or c.pkg_dict %}
+{% set pkg = pkg_dict %}
 {% set name = pkg.title or pkg.name %}
 {% set editor = h.showcase_get_wysiwyg_editor() %}
 
@@ -105,7 +105,7 @@
     {% block secondary_help_content %}{% endblock %}
 
     {% block package_info %}
-        {% snippet 'showcase/snippets/showcase_info.html', pkg=pkg, showcase_pkgs=c.showcase_pkgs %}
+        {% snippet 'showcase/snippets/showcase_info.html', pkg=pkg, showcase_pkgs=showcase_pkgs %}
     {% endblock %}
 
     {% block package_social %}

--- a/ckanext/showcase/templates/showcase/search.html
+++ b/ckanext/showcase/templates/showcase/search.html
@@ -21,10 +21,10 @@
 
 {% block form %}
   {% set facets = {
-    'fields': c.fields_grouped,
-    'search': c.search_facets,
-    'titles': c.facet_titles,
-    'translated_fields': c.translated_fields,
+    'fields': fields_grouped,
+    'search': search_facets,
+    'titles': facet_titles,
+    'translated_fields': translated_fields,
     'remove_field': h.facet_remove_field }
   %}
   {% set sorting = [
@@ -34,11 +34,11 @@
     (_('Last Modified'), 'metadata_modified desc'),
     (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ]
   %}
-  {% snippet 'showcase/snippets/showcase_search_form.html', type='showcase', placeholder=_('Search showcases...'), query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, facets=facets, show_empty=request.args, error=c.query_error, fields=c.fields, no_bottom_border=true %}
+  {% snippet 'showcase/snippets/showcase_search_form.html', type='showcase', placeholder=_('Search showcases...'), query=q, sorting=sorting, sorting_selected=sort_by_selected, count=page.item_count, facets=facets, show_empty=request.args, error=query_error, fields=fields, no_bottom_border=true %}
 {% endblock %}
 
 {% block package_search_results_list %}
-  {{ h.snippet('showcase/snippets/showcase_list.html', packages=c.page.items) }}
+  {{ h.snippet('showcase/snippets/showcase_list.html', packages=page.items) }}
 {% endblock %}
 
 {% block package_search_results_api %}
@@ -48,8 +48,8 @@
 {{ h.snippet('showcase/snippets/helper.html') }}
 <div class="filters">
   <div>
-    {% for facet in c.facet_titles %}
-      {{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet, search_facets=c.search_facets) }}
+    {% for facet in facet_titles %}
+      {{ h.snippet('snippets/facet_list.html', title=facet_titles[facet], name=facet, search_facets=search_facets) }}
     {% endfor %}
   </div>
   <a class="close no-text hide-filters"><i class="fa fa-times-circle icon-remove-sign"></i><span class="text">close</span></a>

--- a/ckanext/showcase/templates/showcase/search.html
+++ b/ckanext/showcase/templates/showcase/search.html
@@ -49,7 +49,7 @@
 <div class="filters">
   <div>
     {% for facet in c.facet_titles %}
-      {{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet) }}
+      {{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet, search_facets=c.search_facets) }}
     {% endfor %}
   </div>
   <a class="close no-text hide-filters"><i class="fa fa-times-circle icon-remove-sign"></i><span class="text">close</span></a>

--- a/ckanext/showcase/utils.py
+++ b/ckanext/showcase/utils.py
@@ -87,7 +87,8 @@ def read_view(id):
 
     package_type = DATASET_TYPE_NAME
     return tk.render('showcase/read.html',
-                     extra_vars={'dataset_type': package_type})
+                     extra_vars={'dataset_type': package_type,
+                                 'pkg_dict': tk.g.pkg_dict,})
 
 
 def manage_datasets_view(id):
@@ -182,7 +183,18 @@ def manage_datasets_view(id):
             'showcase_id': tk.g.pkg_dict['id']
         })
 
-    return tk.render('showcase/manage_datasets.html')
+    extra_vars = {
+        'facet_titles': tk.g.facet_titles,
+        'fields_grouped': tk.g.fields_grouped,
+        'page': tk.g.page,
+        'pkg_dict': tk.g.pkg_dict,
+        'remove_field': tk.g.remove_field,
+        'search_facets': tk.g.search_facets,
+        'showcase_pkgs': tk.g.showcase_pkgs
+    }
+
+    return tk.render('showcase/manage_datasets.html',
+                     extra_vars=extra_vars)
 
 
 def _add_dataset_search(showcase_id, showcase_name):
@@ -423,7 +435,8 @@ def delete_view(id):
         tk.abort(404, _('Showcase not found'))
 
     return tk.render('showcase/confirm_delete.html',
-                     extra_vars={'dataset_type': DATASET_TYPE_NAME})
+                     extra_vars={'dataset_type': DATASET_TYPE_NAME,
+                                 'pkg_dict': tk.g.pkg_dict})
 
 
 def dataset_showcase_list(id):
@@ -500,8 +513,14 @@ def dataset_showcase_list(id):
                            for showcase in site_showcases
                            if showcase['id'] not in pkg_showcase_ids]
 
+    extra_vars = {
+        'pkg_dict': tk.g.pkg_dict,
+        'showcase_dropdown': tk.g.showcase_dropdown,
+        'showcase_list': tk.g.showcase_list,
+    }
+
     return tk.render("package/dataset_showcase_list.html",
-                     extra_vars={'pkg_dict': tk.g.pkg_dict})
+                     extra_vars=extra_vars)
 
 
 def manage_showcase_admins():
@@ -540,7 +559,8 @@ def manage_showcase_admins():
 
     tk.g.showcase_admins = tk.get_action('ckanext_showcase_admin_list')({},{})
 
-    return tk.render('admin/manage_showcase_admins.html')
+    return tk.render('admin/manage_showcase_admins.html',
+                     extra_vars={'showcase_admins': tk.g.showcase_admins})
 
 
 def remove_showcase_admin():

--- a/ckanext/showcase/views.py
+++ b/ckanext/showcase/views.py
@@ -95,7 +95,7 @@ class EditView(dataset.EditView):
             error_summary = e.error_summary
             return self.get(id, data_dict, errors, error_summary)
 
-        tk.c.pkg_dict = pkg
+        tk.g.pkg_dict = pkg
 
         # redirect to showcase details page
         url = h.url_for('showcase_blueprint.read', id=pkg['name'])


### PR DESCRIPTION
This PR was initially just to pass in the `search_facets` parameter into the `facet_list.html` template, as it's now required. Then I got the idea of cleaning up the old `c` object from the templates too.

@pdelboca Do I have it right that we should be passing these extra variables along as `extra_vars` and *not* adding them to the `g` object, in the views? I didn't change that yet, but I can also clean up the places where we add to the `g` object there as well.