### PR TITLE
Use empty string for image alt text

### DIFF
--- a/ckanext/showcase/templates/showcase/read.html
+++ b/ckanext/showcase/templates/showcase/read.html
@@ -71,7 +71,7 @@
         </h1>
 
         {% if pkg.image_display_url %}
-            <p class="ckanext-showcase-image-container"><img src="{{ pkg.image_display_url }}" alt="{{ name }}" class="media-image ckanext-showcase-image img-fluid"></p>
+            <p class="ckanext-showcase-image-container"><img src="{{ pkg.image_display_url }}" alt="" class="media-image ckanext-showcase-image img-fluid"></p>
         {% endif %}
 
     {% block package_notes %}

--- a/ckanext/showcase/templates/showcase/snippets/showcase_item.html
+++ b/ckanext/showcase/templates/showcase/snippets/showcase_item.html
@@ -20,7 +20,7 @@ show_remove    - If True, show the remove button to remove showcase/dataset asso
 <li class="media-item">
   {% block item_inner %}
     {% block image %}
-      <img src="{{ package.image_display_url or h.url_for_static('/base/images/placeholder-group.png') }}" alt="{{ package.name }}" class="media-image img-fluid">
+      <img src="{{ package.image_display_url or h.url_for_static('/base/images/placeholder-group.png') }}" alt="" class="media-image img-fluid">
     {% endblock %}
     {% block title %}
       <h3 class="media-heading">{{ h.link_to(title|truncate(truncate_title), h.url_for(showcase_read_route, id=package.name)) }}</h3>


### PR DESCRIPTION
As long as there is no way to enter a meaningful image description, setting the alt text to an empty string is preferable to the not even human readable showcase name attribute. This is a start towards #181.