### PR TITLE
Munge title strings for better sorting

### DIFF
--- a/ckanext/showcase/plugin.py
+++ b/ckanext/showcase/plugin.py
@@ -9,7 +9,7 @@ import ckan.plugins as plugins
 import ckan.plugins.toolkit as tk
 import ckan.lib.plugins as lib_plugins
 import ckan.lib.helpers as h
-
+from ckan.lib.munge import munge_title_to_name
 
 from ckanext.showcase import cli
 from ckanext.showcase import utils
@@ -171,6 +171,16 @@ class ShowcasePlugin(plugins.SingletonPlugin, lib_plugins.DefaultDatasetForm):
             search_params.update({'fq': fq + " -" + filter})
         return search_params
 
+    def before_dataset_index(self, pkg_dict):
+        '''Modify pkg_dict that is sent to Solr for indexing.'''
+        if pkg_dict["type"] != DATASET_TYPE_NAME:
+            return pkg_dict
+
+        title_string = pkg_dict["title_string"]
+        pkg_dict["title_string"] = munge_title_to_name(title_string)
+
+        return pkg_dict
+
     # CKAN < 2.10 (Remove when dropping support for 2.9)
     def after_show(self, context, pkg_dict):
         '''Modify package_show pkg_dict.'''
@@ -187,6 +197,10 @@ class ShowcasePlugin(plugins.SingletonPlugin, lib_plugins.DefaultDatasetForm):
         `showcase`.
         '''
         return self.before_dataset_search(search_params)
+
+    def before_index(self, pkg_dict):
+        '''Modify pkg_dict that is sent to Solr for indexing.'''
+        return self.before_dataset_index(pkg_dict)
 
     # ITranslation
     def i18n_directory(self):

--- a/ckanext/showcase/plugin.py
+++ b/ckanext/showcase/plugin.py
@@ -173,11 +173,11 @@ class ShowcasePlugin(plugins.SingletonPlugin, lib_plugins.DefaultDatasetForm):
 
     def before_dataset_index(self, pkg_dict):
         '''Modify pkg_dict that is sent to Solr for indexing.'''
-        if pkg_dict["type"] != DATASET_TYPE_NAME:
+        if pkg_dict['type'] != DATASET_TYPE_NAME:
             return pkg_dict
 
-        title_string = pkg_dict["title_string"]
-        pkg_dict["title_string"] = munge_title_to_name(title_string)
+        title_string = pkg_dict.get('title_string', '')
+        pkg_dict['title_string'] = munge_title_to_name(title_string)
 
         return pkg_dict
 


### PR DESCRIPTION
If we have the following four showcases and sort the showcase index page by 'Name Ascending', we ought to see:

- anna's Showcase
- Bob's Showcase
- Ömer's Showcase
- "Petra"'s Showcase

With the current state of the code, we would see:

- "Petra"'s Showcase
- Bob's Showcase
- anna's Showcase
- Ömer's Showcase
