### PR TITLE
Use show extras schema for showcase output

### DIFF
--- a/ckanext/showcase/logic/schema.py
+++ b/ckanext/showcase/logic/schema.py
@@ -5,6 +5,12 @@ from ckan.logic.schema import (default_tags_schema,
                                default_extras_schema,
                                default_resource_schema)
 
+try:
+    from ckan.logic.schema import default_show_extras_schema
+except ImportError:
+    # CKAN 2.10 does not provide a separate show extras schema.
+    default_show_extras_schema = default_extras_schema
+
 from ckanext.showcase.logic.validators import (
     convert_package_name_or_id_to_id_for_type_dataset,
     convert_package_name_or_id_to_id_for_type_showcase)
@@ -83,6 +89,9 @@ def showcase_show_schema():
     schema = showcase_base_schema()
     # Don't strip ids from package dicts when validating them.
     schema['id'] = []
+
+    # Replace the create/update extras schema for show-time processing.
+    schema['extras'] = default_show_extras_schema()
 
     schema.update({
         'tags': {'__extras': [keep_extras]}})


### PR DESCRIPTION
`showcase_show_schema()` currently inherits `default_extras_schema()` from `showcase_base_schema()`. In CKAN 2.12, that schema includes unicode_safe in its extra value validators.

After convert_from_extras extracts and removes the image_url extra, the create/update schema recreates part of the consumed entry as: {"value": ""}

This malformed extra is cached in `validated_data_dict` and causes downstream extensions such as `ckanext-dcat` to raise KeyError: 'key'.

This change replaces the extras schema during show-time processing with `default_show_extras_schema()`. It preserves the extracted image_url while preventing the malformed extra from being created. CKAN 2.10 falls back to `default_extras_schema()` for compatibility.